### PR TITLE
fix syntax for figshare link

### DIFF
--- a/index.md
+++ b/index.md
@@ -121,8 +121,9 @@ suitable for working with Big Data.
 
 The best platforms for publishing ActivePapers are currently
 [figshare](http://figshare.com/) and [Zenodo](http://zenodo.org). You
-can consult the list of ActivePapers available [on figshare]
-(http://figshare.com/search?q=ActivePapers) and
+can consult the list of ActivePapers available
+[on figshare](http://figshare.com/search?q=ActivePapers)
+and
 [on Zenodo](https://zenodo.org/search?f=keyword&p="ActivePapers").
 
 For keeping up to date with ActivePapers development,


### PR DESCRIPTION
I didn't setup the publishing on my computer but from memory there
can be no linebreak between the square bracket and the parenthesis
for a link. GitHub's preview seems to agree :-)

Currently the rendering on http://www.activepapers.org/ is

```
[on figshare] (http://figshare.com/search?q=ActivePapers)
```
